### PR TITLE
Add python3 compatibility

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -103,7 +103,7 @@ publish_log = env.Command(
 Alias('publish-docs', publish_log)
 
 if GetOption('help'):
-    print 'Available Build Aliases:'
-    print '-----'
+    print('Available Build Aliases:')
+    print('-----')
     for alias in sorted(SCons.Node.Alias.default_ans.keys()):
-        print alias
+        print(alias)

--- a/bioscons/__init__.py
+++ b/bioscons/__init__.py
@@ -76,7 +76,7 @@ def package_data(fname, pattern=None):
 try:
     with open(package_data('ver')) as v:
         ver = v.read().strip()
-except Exception, e:
+except Exception as e:
     sys.stderr.write('Error: cannot read {}/ver\n'.format(_data))
     ver = 'v0.0.0.unknown'
 

--- a/bioscons/fileutils.py
+++ b/bioscons/fileutils.py
@@ -13,8 +13,8 @@ else:
         source - filename
         """
 
-        (sname,) = map(str, source)
-        (tname,) = map(str, target)
+        (sname,) = list(map(str, source))
+        (tname,) = list(map(str, target))
 
         if os.path.isdir(tname):
             target = path.join(tname, path.split(sname)[1])
@@ -34,7 +34,7 @@ else:
         source - file compressed using bzip2
         """
 
-        (sname,) = map(str, source)
+        (sname,) = list(map(str, source))
         return sname.replace('.bz2', ''), source
 
     bunzip2 = Builder(
@@ -89,12 +89,12 @@ else:
 
             extras = outfiles - self.targets
             if extras:
-                print '\nextraneous files in %s:' % directory
+                print('\nextraneous files in %s:' % directory)
                 if one_line:
-                    print '  ' + ' '.join(sorted(extras))
+                    print('  ' + ' '.join(sorted(extras)))
                 else:
-                    print '\n'.join(sorted(extras))
-                print
+                    print('\n'.join(sorted(extras)))
+                print()
 
 
 def rename(fname, ext=None, pth=None):

--- a/bioscons/slurm.py
+++ b/bioscons/slurm.py
@@ -25,7 +25,7 @@ def check_srun():
     """
 
     try:
-        srun = subprocess.check_output(['which', 'srun']).strip()
+        srun = subprocess.check_output(['which', 'srun']).strip().decode("utf-8") 
     except subprocess.CalledProcessError:
         srun = None
 
@@ -157,9 +157,9 @@ class SlurmEnvironment(SConsEnvironment):
 
     def Command(self, target, source, action,
                 use_cluster=True, time=True, **kw):
-        if isinstance(action, basestring) and use_cluster and self.use_cluster:
+        if isinstance(action, str) and use_cluster and self.use_cluster:
             return self.SRun(target, source, action, time=time, **kw)
-        elif isinstance(action, basestring) and time and self.time:
+        elif isinstance(action, str) and time and self.time:
             action = _time + action
             return super(SlurmEnvironment, self).Command(
                 target, source, action, **kw)

--- a/bioscons/utils.py
+++ b/bioscons/utils.py
@@ -15,9 +15,9 @@ class verbose(object):
         self.f = f
 
     def __call__(self, *args, **kwargs):
-        print "entering", self.f.__name__, 'called with arguments', args, kwargs
+        print("entering", self.f.__name__, 'called with arguments', args, kwargs)
         self.f(*args, **kwargs)
-        print "exiting", self.f.__name__
+        print("exiting", self.f.__name__)
 
 
 def getvars(config, secnames, indir=None, outdir=None,

--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -200,7 +200,7 @@ def download_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
     try:
         from urllib.request import urlopen
     except ImportError:
-        from urllib2 import urlopen
+        from urllib.request import urlopen
     tgz_name = "distribute-%s.tar.gz" % version
     url = download_base + tgz_name
     saveto = os.path.join(to_dir, tgz_name)

--- a/examples/slurm_examples/slurm_queue_all.py
+++ b/examples/slurm_examples/slurm_queue_all.py
@@ -12,7 +12,7 @@ BIG_SLEEP = 10 * 60 ## 10 minutes
 n_inner_loop = 1 ## used to be 3, but exclude is working better now?
 
 if len(argv) not in [ 5, 6]:
-    print '\nUsage:\n\n%s   <job-tag>   <executable>   <args-file>    "submit-log-message" {nloop}\n\n'%(argv[0])
+    print('\nUsage:\n\n%s   <job-tag>   <executable>   <args-file>    "submit-log-message" {nloop}\n\n'%(argv[0]))
     exit(0)
 
 tag = argv[1]
@@ -26,7 +26,7 @@ else:
 
 first_infofile = 'slurm_queue/%s.1.info'%tag
 if exists( first_infofile ):
-    print 'nonunique tagbase?',tag,first_infofile,'already exists!'
+    print('nonunique tagbase?',tag,first_infofile,'already exists!')
     exit()
 
 partitions = [ 'br2norm', 'br3norm', 'br1norm', 'publow', 'csquid1base', 'qgelow', 'upbase', 'emlow', 'edrnlow',
@@ -49,21 +49,21 @@ for loop in range( nloop ):
                 under_partitions = slurm_util.get_partitions_with_underutilized_nodes()
                 if partition in under_partitions:
                     cmd = '/home/pbradley/slurm_queue.py %s %s %s %s under "%s"'%( mytag, executable, args_file, partition, msg )
-                    print cmd
+                    print(cmd)
                     system(cmd)
 
             else:
                 cmd = '/home/pbradley/slurm_queue.py %s %s %s %s idle "%s"'%( mytag, executable, args_file, partition, msg )
-                print cmd
+                print(cmd)
                 system(cmd)
 
-            print 'sleeping',SMALL_SLEEP,'seconds'
+            print('sleeping',SMALL_SLEEP,'seconds')
             time.sleep( SMALL_SLEEP )
-        print 'sleeping',SLEEP,'seconds'
+        print('sleeping',SLEEP,'seconds')
         time.sleep( SLEEP )
 
 
 
 
-    print 'sleeping',BIG_SLEEP,'seconds'
+    print('sleeping',BIG_SLEEP,'seconds')
     time.sleep( BIG_SLEEP )

--- a/template/SConstruct
+++ b/template/SConstruct
@@ -1,14 +1,14 @@
 import os
-import ConfigParser
+import configparser
 
 import sconstools.utils as utils
 
 #### define variables
-config = ConfigParser.SafeConfigParser()
+config = configparser.SafeConfigParser()
 config.optionxform = str # preserve case of options
 
 setupfile = 'setup.ini'
-print 'reading configuration from %s' % setupfile
+print('reading configuration from %s' % setupfile)
 config.read(setupfile)
 
 basedir = os.path.abspath(config.get('DEFAULT','basedir'))

--- a/tests/slurm/SConstruct
+++ b/tests/slurm/SConstruct
@@ -6,11 +6,11 @@ import subprocess
 
 from bioscons.slurm import SlurmEnvironment, check_srun
 
-print path.join(path.split(path.abspath('.'))[-1],
-                str(call_stack[-1].sconscript))
+print(path.join(path.split(path.abspath('.'))[-1],
+                str(call_stack[-1].sconscript)))
 
 if not check_srun():
-    print '--> srun not found; skipping tests requiring slurm'
+    print('--> srun not found; skipping tests requiring slurm')
     Return([])
 
 vars = Variables()

--- a/tests/slurm/SConstruct-hutch
+++ b/tests/slurm/SConstruct-hutch
@@ -6,11 +6,11 @@ import subprocess
 
 from bioscons.slurm import SlurmEnvironment, check_srun
 
-print path.join(path.split(path.abspath('.'))[-1],
-                str(call_stack[-1].sconscript))
+print(path.join(path.split(path.abspath('.'))[-1],
+                str(call_stack[-1].sconscript)))
 
 if not check_srun():
-    print '--> srun not found; skipping tests requiring slurm'
+    print('--> srun not found; skipping tests requiring slurm')
     Return([])
 
 vars = Variables()
@@ -27,7 +27,7 @@ at_hutch = os.path.exists(slurm_conf) and \
            'PartitionName=full' in open(slurm_conf).read()
 
 if not at_hutch:
-    print '--> skipping hutch-specific tests'
+    print('--> skipping hutch-specific tests')
     Return([])
 
 env = SlurmEnvironment(ENV=os.environ, variables=vars,

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -10,7 +10,7 @@ class TestSlurmFunctions(unittest.TestCase):
 
     def test_check_slurm(self):
         srun = slurm.check_srun()
-        print srun
+        print(srun)
         if srun:
             self.assertTrue(srun.endswith('srun'))
 


### PR DESCRIPTION
Enable python3 compatibility while maintaining backwards compatibility with python2.  Needs a little work to handle requirements differences since scons only supports python 3.5+ starting with version 3.0.0.